### PR TITLE
keyfactor-auth-client-go v1.3.1: Cache Access Token Provider across HttpClient instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.3.1
+## Fixes
+- Reuse OAuth2 token source to prevent unnecessary token fetches for each request.
+
 # v1.3.0
 
 ## Features

--- a/auth_providers/auth_oauth.go
+++ b/auth_providers/auth_oauth.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Keyfactor
+// Copyright 2026 Keyfactor
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -115,6 +116,10 @@ type CommandConfigOauth struct {
 
 	// TokenURL is the token URL for OAuth authentication
 	TokenURL string `json:"token_url,omitempty" yaml:"token_url,omitempty"`
+
+	// unexported: lazily initialized, shared across GetHttpClient() calls
+	tokenSource oauth2.TokenSource
+	tsMu        sync.Mutex
 }
 
 // NewOAuthAuthenticatorBuilder creates a new CommandConfigOauth instance.
@@ -222,7 +227,14 @@ func (b *CommandConfigOauth) GetHttpClient() (*http.Client, error) {
 	}
 
 	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, &http.Client{Transport: baseTransport})
-	tokenSource := config.TokenSource(ctx)
+
+	// Lazily initialize the token source and cache it
+	b.tsMu.Lock()
+	if b.tokenSource == nil {
+		b.tokenSource = config.TokenSource(ctx)
+	}
+	tokenSource := b.tokenSource
+	b.tsMu.Unlock()
 
 	client = http.Client{
 		Transport: &oauth2Transport{

--- a/auth_providers/auth_oauth.go
+++ b/auth_providers/auth_oauth.go
@@ -231,6 +231,7 @@ func (b *CommandConfigOauth) GetHttpClient() (*http.Client, error) {
 	// Lazily initialize the token source and cache it
 	b.tsMu.Lock()
 	if b.tokenSource == nil {
+		log.Printf("[DEBUG] Initializing OAuth2 token source for client ID: %s", b.ClientID)
 		b.tokenSource = config.TokenSource(ctx)
 	}
 	tokenSource := b.tokenSource

--- a/auth_providers/auth_oauth_test.go
+++ b/auth_providers/auth_oauth_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/Keyfactor/keyfactor-auth-client-go/auth_providers"
@@ -572,11 +573,11 @@ func DownloadCertificate(input string, outputPath string) error {
 }
 
 func TestCommandConfigOauth_TokenSourceIsReused(t *testing.T) {
-	tokenRequestCount := 0
+	var tokenRequestCount atomic.Int32
 
 	// Fake IdP token endpoint
 	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		tokenRequestCount++
+		tokenRequestCount.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"access_token": "shared-test-token",
@@ -605,13 +606,14 @@ func TestCommandConfigOauth_TokenSourceIsReused(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GetHttpClient() call %d failed: %v", i+1, err)
 		}
-		_, err = client.Get(apiServer.URL)
+		resp, err := client.Get(apiServer.URL)
 		if err != nil {
 			t.Fatalf("request %d failed: %v", i+1, err)
 		}
+		resp.Body.Close()
 	}
 
-	if tokenRequestCount != 1 {
-		t.Errorf("expected token endpoint to be called once, got %d — token source is not being reused across GetHttpClient() calls", tokenRequestCount)
+	if tokenRequestCount.Load() != 1 {
+		t.Errorf("expected token endpoint to be called once, got %d — token source is not being reused across GetHttpClient() calls", tokenRequestCount.Load())
 	}
 }

--- a/auth_providers/auth_oauth_test.go
+++ b/auth_providers/auth_oauth_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Keyfactor
+// Copyright 2026 Keyfactor
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,9 +16,11 @@ package auth_providers_test
 
 import (
 	"crypto/tls"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -567,4 +569,49 @@ func DownloadCertificate(input string, outputPath string) error {
 
 	fmt.Printf("Certificate chain saved to: %s\n", outputFile)
 	return nil
+}
+
+func TestCommandConfigOauth_TokenSourceIsReused(t *testing.T) {
+	tokenRequestCount := 0
+
+	// Fake IdP token endpoint
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenRequestCount++
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "shared-test-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer tokenServer.Close()
+
+	// Fake API endpoint (just needs to accept requests)
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer apiServer.Close()
+
+	config := &auth_providers.CommandConfigOauth{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		TokenURL:     tokenServer.URL + "/token",
+	}
+
+	// Get multiple clients from the same config
+	const numClients = 3
+	for i := 0; i < numClients; i++ {
+		client, err := config.GetHttpClient()
+		if err != nil {
+			t.Fatalf("GetHttpClient() call %d failed: %v", i+1, err)
+		}
+		_, err = client.Get(apiServer.URL)
+		if err != nil {
+			t.Fatalf("request %d failed: %v", i+1, err)
+		}
+	}
+
+	if tokenRequestCount != 1 {
+		t.Errorf("expected token endpoint to be called once, got %d — token source is not being reused across GetHttpClient() calls", tokenRequestCount)
+	}
 }


### PR DESCRIPTION
This solution lazily initialize the OAuth token source only once, so that a new token source is not generated every time an HttpClient is created. 

Previously, each call to `GettHttpClient` created a fresh OAuth token source with its own empty cache, causing a new access token to fetched from the IdP on every call.

Now, a static OAuth token source is shared across all HttpClient calls to fetch and cache the access token on its end. The OAuth token source will automatically fetch new access tokens from the IdP if the previous access token has expired, i.e. the lifespan of the token has elapsed (typically > 1 hour, depending on IdP configuration), or if the token is close to expiry (~10 second buffer).

The mutex prevents a race condition problem where multiple routines try to instantiate the token source simultaneously. The tokenSource is copied to a local variable so a stable, valid pointer is referenced when a new token is issued.

**Edge cases considered:**
- Token revocation
	- The OAuth token source does not handle scenarios where the access token has been *revoked* by the IdP. I've validated with the Command team that Command only operates with JWT access tokens and only verifies the JWT has not expired and the signature is valid against the IdP's keys, and does not check the IdP whether an access token has been revoked. This scenario should most likely not impact any authenticated calls against Command.
- Access token context sharing
	- In the context of the command-cert-manager-issuer, the OAuth token source will not be shared across multiple containers and will reinstantiate the OAuth token source when the pod restarts. The OAuth token source is only shared by the process running it and its associated threads. There should not be any risk of the access token being leaked to unauthorized processes.